### PR TITLE
fixing help <x> command for inputs that aren't recognized as actions

### DIFF
--- a/server/actions/Help.java
+++ b/server/actions/Help.java
@@ -32,6 +32,7 @@ public class Help implements Action {
     @Override
     public StringBuilder run(Player player, List<Player> players, World world) {
         StringBuilder out = new StringBuilder();
+        help = help.toLowerCase();
         if(help == null) {
             out.append("welcome to the help menu!\n");
             out.append("type 'help action' to list all the stuff you can do!\n");
@@ -65,8 +66,8 @@ public class Help implements Action {
                 String fullActionName = a.getClass().getName();
                 int index = fullActionName.lastIndexOf('.');
                 String actionName = fullActionName.substring(index == -1 ? 0 : index + 1, fullActionName.length());
-                if(actionName.toLowerCase().contains(help)) {
-                    if(!found) {                        
+                if (actionName.toLowerCase().contains(help) || a.description().toLowerCase().contains(help)) {
+                    if (!found) {
                         out.append("did you mean: \n");
                         found = true;
                     }
@@ -75,10 +76,10 @@ public class Help implements Action {
                     out.append(a.description());
                     out.append("\n");
                 }
+            }
 
-                if(!found) {
-                    out.append("could not find any action that matches your query.");
-                }
+            if(!found) {
+                out.append("There is no action related to '" + help + "'. type 'help action' for a list of all the actions.");
             }
         }
         return out;


### PR DESCRIPTION
fixes #12 
The bug was that there was code running inside a loop that should have run after the loop. I additionally changed the message received by the client when there is no action that matches their command to be more specific.